### PR TITLE
Corrects an issue with getting the 'text' body in some instances

### DIFF
--- a/lib/MimeMailParser/Parser.php
+++ b/lib/MimeMailParser/Parser.php
@@ -202,7 +202,7 @@ class Parser
 		);
 		if (in_array($type, array_keys($mime_types))) {
 			foreach ($this->parts as $part) {
-				if ($this->getPartContentType($part) == $mime_types[$type]) {
+				if ($this->getPartContentType($part) == $mime_types[$type] && !$this->getPartContentDisposition($part)) {
 					$headers = $this->getPartHeaders($part);
 					$body = $this->decode($this->getPartBody($part), array_key_exists('content-transfer-encoding', $headers) ? $headers['content-transfer-encoding'] : '');
 				}


### PR DESCRIPTION
If the email contains a text body, and an attached text (text/plain) file then getMessageBody('text') will return the text file instead of the actual text body. This patch resolves that by only treating message parts without a content-disposition header as body.
