### PR TITLE
Define dependencies in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
 	],
 	"require": {
 		"php": ">=5.3",
-        "ext-mbstring" : "*",
-        "ext-mailparse" : "*"
+		"ext-mbstring": "*",
+		"ext-mailparse": "*"
 	},
 	"autoload": {
 		"psr-0": {


### PR DESCRIPTION
Composer has support to require PHP extensions. I added mcrypt and mailparse so this lib won't install without these extensions.
