### PR TITLE
changed some private methods to protected

### DIFF
--- a/lib/MimeMailParser/Parser.php
+++ b/lib/MimeMailParser/Parser.php
@@ -414,11 +414,12 @@ class Parser
 				$len = $end - $start;
 				$written = 0;
 				$write = 2028;
-				$body = '';
 				while ($written < $len) {
-					if (($written + $write < $len)) {
-						$write = $len - $written;
-					}
+                    if (($written + $write < $len)) {
+                        $write = $len - $written;
+                    } else if ($len < $write) {
+                        $write = $len;
+                    }
 					$part = fread($this->stream, $write);
 					fwrite($temp_fp, $this->decode($part, $encoding));
 					$written += $write;


### PR DESCRIPTION
Do some of these private methods need to be private? While trying to extend this class for local needs, where for example attachment streams were not needed and trying to omit the necessity to open streams in getAttachments() method, I ran into private methods and changed them to protected. What do you think?
