### PR TITLE
try content-name if disposition-filename isn't set

### DIFF
--- a/lib/MimeMailParser/Parser.php
+++ b/lib/MimeMailParser/Parser.php
@@ -255,7 +255,7 @@ class Parser
 			$disposition = $this->getPartContentDisposition($part);
 			if (in_array($disposition, $dispositions)) {
 				$attachments[] = new Attachment(
-						$part['disposition-filename'],
+						!empty($part['disposition-filename']) ? $part['disposition-filename'] : $part['content-name'],
 						$this->getPartContentType($part),
 						$this->getAttachmentStream($part),
 						$disposition,


### PR DESCRIPTION
I've encountered attachments where content-name is set instead of disposition-filename in the result of `mailparse_msg_get_part_data`, I assume because the part's header only has a filename under the content header and not the disposition header

```
Content-Type: application/octet-stream; name="filename.csv"
Content-Transfer-Encoding: base64
Content-Disposition: attachment
```

whereas an attachment that successfully parses already has the filename under both headers:

```
Content-Type: text/csv; charset=us-ascii; 
        name=filename.csv
Content-Transfer-Encoding: 7bit
Content-Disposition: attachment; 
        filename=filename.csv
```
