### PR TITLE
getMessageBody does not handle Content-disposition inline fix

### DIFF
--- a/lib/MimeMailParser/Parser.php
+++ b/lib/MimeMailParser/Parser.php
@@ -207,7 +207,7 @@ class Parser
 		);
 		if (in_array($type, array_keys($mime_types))) {
 			foreach ($this->parts as $part) {
-				if ($this->getPartContentType($part) == $mime_types[$type] && !$this->getPartContentDisposition($part)) {
+				if ($this->getPartContentType($part) == $mime_types[$type] && (!$this->getPartContentDisposition($part) || $this->getPartContentDisposition($part) === 'inline')) {
 					$headers = $this->getPartHeaders($part);
 					$body = $this->decode($this->getPartBody($part), array_key_exists('content-transfer-encoding', $headers) ? $headers['content-transfer-encoding'] : '');
 				}


### PR DESCRIPTION
This seems to fix issue #10 that causes empty body on emails with Content-disposition: inline set.